### PR TITLE
В модулях js/form.js и js/filter.js убран this вне объекта

### DIFF
--- a/js/form-field.js
+++ b/js/form-field.js
@@ -4,12 +4,6 @@
  * Абстрактный объект для работы с полями формы объявления. Создается через
  * конструктор Field (снаружи модуля — window.FormField) и настраивается
  * при помощи методов, определенных через прототип.
- *
- * Важный комментарий по ESLint — чтобы не передавать в функции фильтрации
- * объект, для получения доступа к его свойствами и атрибутам используется
- * this. ESLint это не нравится, но лишние данные гонять через параметры
- * функции интутивно кажется еще хуже. Поэтому для строчек с this использутеся
- * комментарий "// eslint-disable-line no-invalid-this" который глушит ESLint.
  */
 
 window.FormField = (function () {
@@ -53,15 +47,16 @@ window.FormField = (function () {
   /**
    * Добавляет функцию валидации к полю
    *
-   * @param {function} procedure - функция, валидирующая значение поля. Доступ
-   *                               к свойствам поля осуществляется через this.
-   *                               Функция должна возвращать логическое (bool)
-   *                               значение: если True, то значение прошло
-   *                               проверку, если False — то нет
+   * @param {function} procedure - функция, валидирующая значение поля. Функции
+   *                               передается аргумент в виде объекта для
+   *                               доступа к свойствам и атрибутам. Функция
+   *                               должна возвращать логическое (bool) значние:
+   *                               если True, то значение прошло проверку,
+   *                               если False — то нет
    * @return {undefined}
    */
   Field.prototype.setValidation = function (procedure) {
-    this.validationProcedure = procedure.bind(this);
+    this.validationProcedure = procedure;
   };
 
   /**
@@ -75,7 +70,7 @@ window.FormField = (function () {
    */
   Field.prototype.validate = function (getStatusOnly) {
     if (typeof this.validationProcedure === 'function') {
-      this.isValid = this.validationProcedure();
+      this.isValid = this.validationProcedure(this);
     } else {
       this.isValid = this.element.validity.valid;
     }
@@ -175,8 +170,8 @@ window.FormField = (function () {
       defaultPreview.appendChild(child);
     });
 
-    var uploadPreviewImageHandler = function () {
-      var file = this.element.files[0]; // eslint-disable-line no-invalid-this
+    var uploadPreviewImageHandler = function (evt) {
+      var file = evt.currentTarget.files[0];
       var fileName = file.name.toLowerCase();
 
       var isExtensionValid = FILE_EXTENSIONS.some(function (ext) {
@@ -198,7 +193,7 @@ window.FormField = (function () {
       }
     };
 
-    this.element.addEventListener('change', uploadPreviewImageHandler.bind(this));
+    this.element.addEventListener('change', uploadPreviewImageHandler);
 
     this.setReset(function () {
       window.util.removeElements('*', previewHolder);

--- a/js/form.js
+++ b/js/form.js
@@ -4,11 +4,17 @@
  * Модуль управления полями формы добавления объявления. Поля управляются
  * с помощью объекта window.FormField и его методов.
  *
- * Важный комментарий по ESLint — чтобы не передавать в функции фильтрации
- * объект, для получения доступа к его свойствами и атрибутам используется
- * this. ESLint это не нравится, но лишние данные гонять через параметры
- * функции интутивно кажется еще хуже. Поэтому для строчек с this использутеся
- * комментарий "// eslint-disable-line no-invalid-this" который глушит ESLint.
+ * Важный комментарий по ESLint — у него есть один из критериев валидации,
+ * который вызывает ошибку "Unexpected 'this'" -- по всей видимости, в отношении
+ * функций, которые объяалены вне конструктора и прототипа. Это не дает
+ * возможности создавать функции вне объекта и потом вызывать их в его окружении
+ * с помощью bind. В модуле Form у меня подразумевалась именно такой
+ * подход в отношении функций валидации. Локально я заглушил ESLint для этой
+ * ошибки с помощью комментарий "// eslint-disable-line no-invalid-this",
+ * однако интерфейс htmlacademy.ru игнорирует эту директиву и не дает послать
+ * проект с такой конструкцией. Из-за этого мне пришлось усложнять код
+ * и передавать объект дополнительным параметром функции, что ухудшило
+ * читаемость.
  */
 
 (function () {
@@ -49,8 +55,8 @@
   // Добавление валидации к полю "Тип жилья". Функция всегда возвращает true,
   // но при смене значения обновляет минимальное значение и плейсхолдер для
   // поля цены
-  fields['type'].setValidation(function () {
-    var housingType = window.page.housingTypeMap[this.element.value]; // eslint-disable-line no-invalid-this
+  fields['type'].setValidation(function (field) {
+    var housingType = window.page.housingTypeMap[field.element.value];
     fields['price'].element.min = housingType.minPrice;
     fields['price'].element.placeholder = housingType.minPrice;
     fields['price'].validate();
@@ -60,21 +66,21 @@
   // Добавление валидации к полю "Количество комнат". При изменениии значения
   // проверяет соответствие полю "Количество мест" и сразу отмечает поле
   // невалидным, если оно не соответствует
-  fields['roomNumber'].setValidation(function () {
+  fields['roomNumber'].setValidation(function (field) {
     if (checkRoomsAndCapacity()) {
       return fields['capacity'].setValid();
     }
-    return this.setInvalid(window.page.Message.CAPACITY_ERROR); // eslint-disable-line no-invalid-this
+    return field.setInvalid(window.page.Message.CAPACITY_ERROR);
   });
 
   // Добавление валидации к полю "Количество мест". При изменениии значения
   // проверяет соответствие полю "Количество комнат" и сразу отмечает поле
   // невалидным, если оно не соответствует
-  fields['capacity'].setValidation(function () {
+  fields['capacity'].setValidation(function (field) {
     if (checkRoomsAndCapacity()) {
       return fields['roomNumber'].setValid();
     }
-    return this.setInvalid(window.page.Message.CAPACITY_ERROR); // eslint-disable-line no-invalid-this
+    return field.setInvalid(window.page.Message.CAPACITY_ERROR);
   });
 
   // Добавление валидации к полю "Время заезда". Функция всегда возвращает true,


### PR DESCRIPTION
ESLint не давал пройти валидацию, если в функциях упоминался this
вне конструктора объекта или прототипа. Пришлось изменить структуру
и вызов таких функций.

У ESLint него есть один из критериев валидации, который вызывает ошибку "Unexpected 'this'" -- по всей видимости, в отношении функций, которые объявлены вне конструктора и прототипа. Это не дает возможности создавать функции вне объекта и потом вызывать их в его окружении с помощью bind. В модуле Form у меня подразумевалась именно такой подход в отношении функций валидации. Локально я заглушил ESLint для этой ошибки с помощью комментарий "// eslint-disable-line no-invalid-this", однако интерфейс htmlacademy.ru игнорирует эту директиву и не дает послать проект с такой конструкцией. Из-за этого мне пришлось усложнять код и передавать объект дополнительным параметром функции, что ухудшило читаемость.